### PR TITLE
Model initialization

### DIFF
--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -192,11 +192,11 @@ def main(opt):
         model.to('cuda')
 
     # Load the model states from checkpoint or initialize them.
-    # TODO: add logic for parameter initialization?
     if checkpoint is not None:
         model.load_state_dict(checkpoint['model'])
         #generator.load_state_dict(checkpoint['generator'])
     else:
+        logger.info("Initializing model parameters")
         if model_opt.param_init != 0.0:
             for p in model.parameters():
                 p.data.uniform_(-model_opt.param_init, model_opt.param_init)

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -9,6 +9,7 @@ import os
 import random
 import torch
 import torch.nn as nn
+from torch.nn.init import xavier_uniform_
 
 import onmt.opts as opts
 
@@ -195,6 +196,21 @@ def main(opt):
     if checkpoint is not None:
         model.load_state_dict(checkpoint['model'])
         #generator.load_state_dict(checkpoint['generator'])
+    else:
+        if model_opt.param_init != 0.0:
+            for p in model.parameters():
+                p.data.uniform_(-model_opt.param_init, model_opt.param_init)
+            for generator in generators.values():
+                for p in generator.parameters():
+                    p.data.uniform_(-model_opt.param_init, model_opt.param_init)
+        if model_opt.param_init_glorot:
+            for p in model.parameters():
+                if p.dim() > 1:
+                    xavier_uniform_(p)
+            for generator in generators.values():
+                for p in generator.parameters():
+                    if p.dim() > 1:
+                        xavier_uniform_(p)
 
     n_params, enc, dec = _tally_parameters(model)
     logger.info('encoder: %d' % enc)


### PR DESCRIPTION
Initialize model parameters according to config.

This doesn't seem to have any impact on results, though. By default, PyTorch will initialize the parameters sensibly anyway:

* embeddings: normal distribution, mean 0, stddev 1
* RNN: uniform distribution in range +/- 1/sqrt(hidden_size)