### PR TITLE
enable different encoder types

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -294,8 +294,9 @@ def build_base_multitask_model(model_opt, fields, gpu, encoders, decoders, gener
     Returns:
         the NMTModel.
     """
-    assert model_opt.model_type in ["text", "img", "audio"], \
-            ("Unsupported model type %s" % (model_opt.model_type))
+    for model_type in model_opt.model_type:
+        assert model_type in ["text", "img", "audio"], \
+                ("Unsupported model type %s" % (model_opt.model_type))
 
     device = torch.device("cuda" if gpu else "cpu")
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -59,7 +59,7 @@ def model_opts(parser):
 
     # Encoder-Decoder Options
     group = parser.add_argument_group('Model- Encoder-Decoder')
-    group.add('--model_type', '-model_type', default='text',
+    group.add('--model_type', '-model_type', nargs='+', default='text',
               choices=['text', 'img', 'audio'],
               help="Type of source model to use. Allows "
                    "the system to incorporate non-text inputs. "
@@ -68,7 +68,7 @@ def model_opts(parser):
               choices=['fp32', 'fp16'],
               help='Data type of the model.')
 
-    group.add('--encoder_type', '-encoder_type', type=str, default='rnn',
+    group.add('--encoder_type', '-encoder_type', nargs='+', type=str, default='rnn',
               choices=['rnn', 'brnn', 'mean', 'transformer', 'cnn'],
               help="Type of encoder layer to use. Non-RNN layers "
                    "are experimental. Options are "
@@ -81,23 +81,23 @@ def model_opts(parser):
 
     group.add('--layers', '-layers', type=int, default=-1,
               help='Number of layers in enc/dec.')
-    group.add('--enc_layers', '-enc_layers', type=int, default=2,
+    group.add('--enc_layers', '-enc_layers', nargs='+', type=int, default=2,
               help='Number of layers in the encoder')
-    group.add('--dec_layers', '-dec_layers', type=int, default=2,
+    group.add('--dec_layers', '-dec_layers', nargs='+', type=int, default=2,
               help='Number of layers in the decoder')
     group.add('--rnn_size', '-rnn_size', type=int, default=-1,
               help="Size of rnn hidden states. Overwrites "
                    "enc_rnn_size and dec_rnn_size")
-    group.add('--enc_rnn_size', '-enc_rnn_size', type=int, default=500,
+    group.add('--enc_rnn_size', '-enc_rnn_size' , type=int, default=500,
               help="Size of encoder rnn hidden states. "
                    "Must be equal to dec_rnn_size except for "
                    "speech-to-text.")
-    group.add('--dec_rnn_size', '-dec_rnn_size', type=int, default=500,
+    group.add('--dec_rnn_size', '-dec_rnn_size' , type=int, default=500,
               help="Size of decoder rnn hidden states. "
                    "Must be equal to enc_rnn_size except for "
                    "speech-to-text.")
     group.add('--audio_enc_pooling', '-audio_enc_pooling',
-              type=str, default='1',
+              type=str, nargs='+', default='1',
               help="The amount of pooling of audio encoder, "
                    "either the same amount of pooling across all layers "
                    "indicated by a single number, or different amounts of "
@@ -116,7 +116,7 @@ def model_opts(parser):
     group.add('--bridge', '-bridge', action="store_true",
               help="Have an additional layer between the last encoder "
                    "state and the first decoder state")
-    group.add('--rnn_type', '-rnn_type', type=str, default='LSTM',
+    group.add('--rnn_type', '-rnn_type', type=str, nargs='+', default='LSTM',
               choices=['LSTM', 'GRU', 'SRU'],
               action=CheckSRU,
               help="The gate type to use in the RNNs")

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -48,6 +48,22 @@ def build_dataset_iter_fct(dataset_name, fields_, opt_, data_path, is_train=True
 
     return train_iter_wrapper
 
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+def update_to_local_attr(attribute, index):
+    'return local attribure for encoders and decoders'
+    if type(attribute) is list:
+        if len(attribute) > 1:
+            attr = attribute[index]
+        else:
+            attr = attribute[0]
+    else:
+        attr = attribute
+    return attr
+
 def main(opt, device_id):
     # NOTE: It's important that ``opt`` has been validated and updated
     # at this point.
@@ -88,7 +104,22 @@ def main(opt, device_id):
     # we share the word embedding space when source lang and target lang are the same
     mapLang2Emb = {}
 
-    for (src_tgt_lang), data_path in zip(opt.src_tgt, opt.data):
+    #for (src_tgt_lang), data_path in zip(opt.src_tgt, opt.data):
+    for index in range(len(opt.src_tgt)):
+        src_tgt_lang = opt.src_tgt[index]
+        data_path = opt.data[index]
+        import ipdb; ipdb.set_trace()
+        local_enc_dec_opts = AttrDict({key:model_opt.__dict__[key] for key in model_opt.__dict__.keys()})
+        local_enc_dec_opts.model_type = update_to_local_attr(model_opt.model_type, index)
+        #local_enc_dec_opts.audio_enc_pooling = model_opt.audio_enc_pooling[index] 
+        local_enc_dec_opts.audio_enc_pooling = update_to_local_attr(model_opt.audio_enc_pooling, index)
+        local_enc_dec_opts.enc_layers = update_to_local_attr(model_opt.enc_layers, index) 
+        local_enc_dec_opts.dec_layers = update_to_local_attr(model_opt.dec_layers, index)
+        local_enc_dec_opts.rnn_type   = update_to_local_attr(model_opt.rnn_type, index)
+        local_enc_dec_opts.encoder_type = update_to_local_attr(model_opt.encoder_type, index)
+        #local_enc_dec_opts.dec_rnn_size = model_opt.dec_rnn_size[index]
+
+
         src_lang, tgt_lang = src_tgt_lang.split('-')
 
         vocab = torch.load(data_path + '.vocab.pt')
@@ -113,11 +144,11 @@ def main(opt, device_id):
                     logger.info(' * %s vocab size = %d' % (sn, len(sf.vocab)))
 
         # Build model.
-        encoder, src_embeddings = build_embeddings_then_encoder(model_opt, fields)
+        encoder, src_embeddings = build_embeddings_then_encoder(local_enc_dec_opts, fields)
 
         encoders[src_lang] = encoder
 
-        decoder, generator, tgt_embeddings = build_decoder_and_generator(model_opt, fields)
+        decoder, generator, tgt_embeddings = build_decoder_and_generator(local_enc_dec_opts, fields)
 
         decoders[tgt_lang] = decoder
 

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -108,7 +108,6 @@ def main(opt, device_id):
     for index in range(len(opt.src_tgt)):
         src_tgt_lang = opt.src_tgt[index]
         data_path = opt.data[index]
-        import ipdb; ipdb.set_trace()
         local_enc_dec_opts = AttrDict({key:model_opt.__dict__[key] for key in model_opt.__dict__.keys()})
         local_enc_dec_opts.model_type = update_to_local_attr(model_opt.model_type, index)
         #local_enc_dec_opts.audio_enc_pooling = model_opt.audio_enc_pooling[index] 

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -48,14 +48,16 @@ class ArgumentParser(cfargparse.ArgumentParser):
 
     @classmethod
     def validate_model_opts(cls, model_opt):
-        assert model_opt.model_type in ["text", "img", "audio"], \
-            "Unsupported model type %s" % model_opt.model_type
+        for model_type in model_opt.model_type:
+            assert model_type in ["text", "img", "audio"], \
+                "Unsupported model type %s" % model_opt.model_type
 
         # this check is here because audio allows the encoder and decoder to
         # be different sizes, but other model types do not yet
         same_size = model_opt.enc_rnn_size == model_opt.dec_rnn_size
-        assert model_opt.model_type == 'audio' or same_size, \
-            "The encoder and decoder rnns must be the same size for now"
+        for model_type in model_opt.model_type:
+            assert model_type == 'audio' or same_size, \
+                "The encoder and decoder rnns must be the same size for now"
 
         assert model_opt.rnn_type != "SRU" or model_opt.gpu_ranks, \
             "Using SRU requires -gpu_ranks set."


### PR DESCRIPTION
still have to avoid overwriting to the last specified encoder, when they have the same name (the src in -src_tgt) option