### PR TITLE
Use Mel-scale filterbanks as audio features

### DIFF
--- a/onmt/encoders/audio_encoder.py
+++ b/onmt/encoders/audio_encoder.py
@@ -29,7 +29,7 @@ class AudioEncoder(EncoderBase):
 
     def __init__(self, rnn_type, enc_layers, dec_layers, brnn,
                  enc_rnn_size, dec_rnn_size, enc_pooling, dropout,
-                 sample_rate, window_size):
+                 sample_rate, window_size, n_mels):
         super(AudioEncoder, self).__init__()
         self.enc_layers = enc_layers
         self.rnn_type = rnn_type
@@ -43,7 +43,7 @@ class AudioEncoder(EncoderBase):
         dec_rnn_size_real = dec_rnn_size // num_directions
         self.dec_rnn_size_real = dec_rnn_size_real
         self.dec_rnn_size = dec_rnn_size
-        input_size = int(math.floor((sample_rate * window_size) / 2) + 1)
+        input_size = n_mels
         enc_pooling = enc_pooling.split(',')
         assert len(enc_pooling) == enc_layers or len(enc_pooling) == 1
         if len(enc_pooling) == 1:
@@ -96,7 +96,8 @@ class AudioEncoder(EncoderBase):
             opt.audio_enc_pooling,
             opt.dropout,
             opt.sample_rate,
-            opt.window_size)
+            opt.window_size,
+            opt.n_mels)
 
     def forward(self, src, lengths=None):
         """See :func:`onmt.encoders.encoder.EncoderBase.forward()`"""

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -296,6 +296,8 @@ def preprocess_opts(parser):
               help="Window stride for spectrogram in seconds.")
     group.add('--window', '-window', default='hamming',
               help="Window type for spectrogram generation.")
+    group.add('--n_mels', '-n_mels', type=int, default=80,
+            help="Number Mel-scale filterbanks to extract")
 
     # Option most relevant to image input
     group.add('--image_channel_size', '-image_channel_size',


### PR DESCRIPTION
Hi, this should implement the Mel-scale filterbank energies as features, instead of simple magnitude spectra. However, I do not have OpenNMT setup, and did not test at all. 
Could I ask you to run the simple audio test before merging?