### PR TITLE
Change weight sync strategies

### DIFF
--- a/config/config-wmt_test_2_nodes.yml
+++ b/config/config-wmt_test_2_nodes.yml
@@ -1,0 +1,102 @@
+data:
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.cs-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-et
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.cs-cs
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.de-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-cs
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.de-de
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-de
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.et-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.et-et
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.fi-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-ru
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.fi-fi
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-fi
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.ru-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.ru-ru
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-tr
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.zh-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.tr-tr
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.tr-en
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-zh
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.zh-zh
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-de
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-cs
+  - /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/data/wmt/wmt.en-en
+src_tgt:
+  - cs-en
+  - en-et
+  - cs-cs
+  - de-en
+  - en-cs
+  - de-de
+  - en-de
+  - et-en
+  - et-et
+  - fi-en
+  - en-ru
+  - fi-fi
+  - en-fi
+  - ru-en
+  - ru-ru
+  - en-tr
+  - zh-en
+  - tr-tr
+  - tr-en
+  - en-zh
+  - zh-zh
+  - en-de
+  - en-cs
+  - en-en
+save_model: /scratch/project_2005099/members/micheleb/projects/scaleUpMNMT/models/wmt/m2m.att_bridge.50.adam.ale
+save_checkpoint_steps: 200
+keep_checkpoint: 10
+seed: 3435
+train_steps: 200
+valid_steps: 10000
+warmup_steps: 40
+report_every: 20
+save_all_gpus: 'true'
+
+use_attention_bridge: 'true'
+n_layers_attbrg: 1
+layer_type_attbrg: fixed-size
+hidden_ab_size: 4096
+attention_heads: 50
+
+decoder_type: transformer
+encoder_type: transformer
+word_vec_size: 512
+rnn_size: 512
+dec_layers: 6
+enc_layers: 6
+transformer_ff: 2048
+heads: 8
+model_type: text
+
+accum_count: 1
+optim: adam
+adam_beta1: 0.9
+adam_beta2: 0.998
+decay_method: noam
+learning_rate: 3
+max_grad_norm: 0.0
+
+batch_size: 4096
+batch_type: tokens
+normalization: tokens
+dropout: 0.1
+label_smoothing: 0.1
+
+max_generator_batches: 2
+
+param_init: 0.0
+param_init_glorot: 'true'
+position_encoding: 'true'
+
+world_size: 8
+gpu_ranks:
+  - 0
+  - 1
+  - 2
+  - 3

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -257,7 +257,7 @@ def main(opt, unique_device_id):
                 logger.info("Enc comm group {} {}".format(l, indices))
             all_enc_comms[l] = CommunicationGroup(
                 torch_dist_group=torch.distributed.new_group(indices),
-                group_size=len(indices),
+                indices=indices,
             )
 
     all_dec_comms = OrderedDict()
@@ -270,7 +270,7 @@ def main(opt, unique_device_id):
                 logger.info("Dec comm group {} {}".format(l, indices))
             all_dec_comms[l] = CommunicationGroup(
                 torch_dist_group=torch.distributed.new_group(indices),
-                group_size=len(indices),
+                indices=indices,
             )
 
     # Build model.

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -675,7 +675,7 @@ class Trainer(object):
                         ]
                         # logger.info("GPU {} BEFORE - Enc: group_lang = {}, grads = {}".format(self.gpu_rank, group_lang, grads[2][:10]))
                         onmt.utils.distributed.all_reduce_and_rescale_tensors(
-                            grads, float(1), group=group.torch_dist_group
+                            grads, float(group.size), group=group.torch_dist_group
                         )
                         # logger.info("GPU {} AFTER - Enc: group_lang = {}, grads = {}".format(self.gpu_rank, group_lang, grads[2][:10]))
                     # torch.cuda.synchronize()
@@ -707,7 +707,7 @@ class Trainer(object):
                         ]
                         # logger.info("GPU {} BEFORE - Dec: group_lang = {}, grads = {}".format(self.gpu_rank, group_lang, grads[2][:10]))
                         onmt.utils.distributed.all_reduce_and_rescale_tensors(
-                            grads, float(1), group=group.torch_dist_group
+                            grads, float(group.size), group=group.torch_dist_group
                         )
                         # logger.info("GPU {} AFTER - Dec: group_lang = {}, grads = {}".format(self.gpu_rank, group_lang, grads[2][:10]))
 
@@ -719,7 +719,7 @@ class Trainer(object):
                     and "attention" in p[0]
                     and p[1].grad is not None
                 ]
-                onmt.utils.distributed.all_reduce_and_rescale_tensors(grads, float(1))
+                onmt.utils.distributed.all_reduce_and_rescale_tensors(grads, float(self.n_gpu))
 
             for src_lang in set(src_langs):
                 optim_enc = self.optim["enc"][src_lang]

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -353,7 +353,7 @@ class Trainer(object):
                     )
                 ]
                 onmt.utils.distributed.broadcast_tensors(
-                    params, src=0, group=group.torch_dist_group
+                    params, src=min(group.indices), group=group.torch_dist_group
                 )
         # decoders
         for group_lang, group in self.all_dec_comms.items():
@@ -373,9 +373,9 @@ class Trainer(object):
                     )
                 ]
                 onmt.utils.distributed.broadcast_tensors(
-                    params, src=0, group=group.torch_dist_group
+                    params, src=min(group.indices), group=group.torch_dist_group
                 )
-        # average all attention params across the 'world'
+        # sync attention params across the 'world'
         params = [
             p[1].data for p in self.model.named_parameters() if "attention" in p[0]
         ]

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -352,9 +352,12 @@ class Trainer(object):
                         "encoders.{}".format(self.model.encoder_ids[group_lang])
                     )
                 ]
+                logger.debug("BEFORE - enc lang {}, gpu {}, {}".format(group_lang, self.gpu_rank, params[2][:10]))
+                logger.info("GPU-{}: Broadcasting {} encoder params from source rank {}".format(self.gpu_rank, group_lang, min(group.indices)))
                 onmt.utils.distributed.broadcast_tensors(
                     params, src=min(group.indices), group=group.torch_dist_group
                 )
+                logger.debug("AFTER  - enc lang {}, gpu {}, {}".format(group_lang, self.gpu_rank, params[2][:10]))
         # decoders
         for group_lang, group in self.all_dec_comms.items():
             if (
@@ -372,9 +375,12 @@ class Trainer(object):
                         )
                     )
                 ]
+                logger.debug("BEFORE - dec lang {}, gpu {}, {}".format(group_lang, self.gpu_rank, params[2][:10]))
+                logger.info("GPU-{}: Broadcasting {} decoder params from source rank {}".format(self.gpu_rank, group_lang, min(group.indices)))
                 onmt.utils.distributed.broadcast_tensors(
                     params, src=min(group.indices), group=group.torch_dist_group
                 )
+                logger.debug("AFTER  - dec lang {}, gpu {}, {}".format(group_lang, self.gpu_rank, params[2][:10]))
         # sync attention params across the 'world'
         params = [
             p[1].data for p in self.model.named_parameters() if "attention" in p[0]

--- a/onmt/utils/distributed.py
+++ b/onmt/utils/distributed.py
@@ -101,6 +101,14 @@ def all_reduce_and_rescale_tensors(
         all_reduce_buffer()
 
 
+def broadcast_tensors(tensors, src=0, group=None):
+    for t in tensors:
+        if group is None:
+            torch.distributed.broadcast(t, src)
+        else:
+            torch.distributed.broadcast(t, src, group=group)
+
+
 def all_gather_list(data, max_size=4096):
     """Gathers arbitrary data from all nodes into a list."""
     world_size = torch.distributed.get_world_size()

--- a/onmt/utils/distributed.py
+++ b/onmt/utils/distributed.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 import math
 import pickle
+from typing import List
 
 import torch.distributed
 
@@ -149,7 +150,8 @@ class CommunicationGroup:
     def __init__(
         self,
         torch_dist_group: torch.distributed.distributed_c10d.ProcessGroupNCCL,
-        group_size: int,
+        indices: List[int],
     ):
         self.torch_dist_group = torch_dist_group
-        self.size = group_size
+        self.size = len(indices)
+        self.indices = indices


### PR DESCRIPTION
Changelog:
 * After initialising weights on each device, weights of shared components are broadcasted from rank 0 to other ranks
 * When communicating gradients use average instead of sums of gradients among components